### PR TITLE
Labeling

### DIFF
--- a/PyFOX.py
+++ b/PyFOX.py
@@ -683,8 +683,24 @@ if config_user['flags']['final_flag']:
                     location[l]['LAF'] = config_user['location_library'][l]['LAF']
 
                 for ploc in config_user['dataProperties']['phys_locs']:
+                    # Dictionary for creating physical location.
                     temp_loc = {loc:location[loc] for loc in location if ploc in location[loc]['loc_type']}
+                    # Simplified dictionary for relabeling.
+                    relabel = {loc: location[loc]['LAF'] for loc in location
+                               if ploc == location[loc]['loc_type']}
+                    # Relabel the locations. This allows locations to
+                    # change after calibrating, as the calibration only
+                    # cares about the location of the reference baths.
+                    dstemp = btmm_process.labelLoc_additional(dstemp,
+                                                              relabel,
+                                                              ploc)
+                    # Give the 3D labels.
                     dstemp_out = btmm_process.labeler.dtsPhysicalCoords_3d(dstemp, temp_loc)
+
+                    # Output each location type as a separate final file.
+                    outname = '_'.join(filter(None, [exp_name, 'final',
+                                                     outname_date,
+                                                     outname_suffix,
+                                                     ploc])) + '.nc'
                     os.chdir(internal_config[exp_name]['directories']['dirFinal'])
-                    outname = cal_nc.split('.')[0].replace('cal', 'final') + '_' + ploc + '.nc'
-                    dstemp_out.to_netcdf(outname)
+                    dstemp_out[ploc].to_netcdf(outname, mode='w')

--- a/PyFOX.py
+++ b/PyFOX.py
@@ -531,7 +531,7 @@ if config_user['flags']['final_flag']:
 
     # When finalizing the dataset all extraneous coordinates and data
     # is dropped, leaving behind these variables.
-    coords_to_keep = ['xyz', 'time', 'x', 'y', 'z', 'core']
+    coords_to_keep = ['xyz', 'time', 'x', 'y', 'z', 'core', 'LAF']
     vars_to_keep = ['cal_temp']
     cores_to_proc = list(config_user['dataProperties']['cores'].keys())
 
@@ -596,7 +596,18 @@ if config_user['flags']['final_flag']:
                         if ploc not in dstemp_out:
                             dstemp_out[ploc] = []
                         # Find all the locations to label in this location type
-                        temp_loc = {loc:location[loc] for loc in location if ploc==location[loc]['loc_type']}
+                        temp_loc = {loc: location[loc] for loc in location
+                                    if ploc == location[loc]['loc_type']}
+                        # Simplified dictionary for relabeling.
+                        relabel = {loc: location[loc]['LAF'] for loc in location
+                                   if ploc == location[loc]['loc_type']}
+                        # Relabel the locations. This allows locations to
+                        # change after calibrating, as the calibration only
+                        # cares about the location of the reference baths.
+                        dstemp = btmm_process.labelLoc_additional(dstemp,
+                                                                  relabel,
+                                                                  ploc)
+                        # Assign physical labels
                         dstemp_out[ploc].append(btmm_process.labeler.dtsPhysicalCoords_3d(dstemp, temp_loc))
 
                 # Merge the cores

--- a/btmm_process/labeler.py
+++ b/btmm_process/labeler.py
@@ -310,7 +310,6 @@ def dtsPhysicalCoords_3d(ds, location):
                                          names=('x', 'y', 'z'))
         section.coords['xyz'] = ('LAF', midx)
         section = section.swap_dims({'LAF': 'xyz'})
-        section = section.drop('LAF')
         all_sections.append(section)
 
     # Concatenate along the physical coordinate MultiIndex


### PR DESCRIPTION
This is a major clean-up/feature. Data locations are relabeled according to the configuration file's location library in the final step. Previously the code recycled the location labels assigned during the calibration stage. However, as the work flow more naturally lends itself to adjusting some of the fiber holder artifacts after calibration pyfocs needs to accept new label locations.

Additionally, the final labeled datasets will now have LAF as a coordinate. This facilitates smoothing and further artifact adjustments without re-calibrating.